### PR TITLE
39-evaluation-tool-not-available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ Changes to Calva Backseat Driver
 
 ## [Unreleased]
 
+- Fix: [MakEvaluation tool not available in v0.0.21](https://github.com/BetterThanTomorrow/calva-backseat-driver/issues/39)
+
 ## [v0.0.21] - 2025-09-30
 
-- [Make the structural editing tools return file context when the tool call is invalid ](https://github.com/BetterThanTomorrow/calva-backseat-driver/issues/37)
+- [Make the structural editing tools return file context when the tool call is invalid](https://github.com/BetterThanTomorrow/calva-backseat-driver/issues/37)
   - Add user settings/configurability: `calva-backseat-driver.editor.fuzzyLineTargetingPadding` and `calva-backseat-driver.editor.lineContextResponsePadding`
 
 ## [v0.0.20] - 2025-09-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changes to Calva Backseat Driver
 
 ## [Unreleased]
 
-- Fix: [MakEvaluation tool not available in v0.0.21](https://github.com/BetterThanTomorrow/calva-backseat-driver/issues/39)
+- Fix: [Evaluation tool not available in v0.0.21](https://github.com/BetterThanTomorrow/calva-backseat-driver/issues/39)
 
 ## [v0.0.21] - 2025-09-30
 

--- a/src/calva_backseat_driver/ex/ax.cljs
+++ b/src/calva_backseat_driver/ex/ax.cljs
@@ -42,30 +42,20 @@
        x))
    action-or-effect))
 
-(defn- config-key->path
-  "Extract the configuration path from a placeholder keyword like :vscode/config.editor.foo.
-   Returns nil when the keyword does not follow the expected pattern."
-  [k]
-  (let [k-str (str k)
-        prefix ":vscode/config."]
-    (when (string/starts-with? k-str prefix)
-      (subs k-str (count prefix)))))
-
 (defn- enrich-from-state [action-or-effect state]
   (walk/postwalk
    (fn [x]
-     (let [config-path (config-key->path x)]
-       (cond
-         (and (vector? x)
-              (= :db/get (first x)))
-         (get state (second x))
+     (cond
+       (and (vector? x)
+            (= :db/get (first x)))
+       (get state (second x))
 
-         config-path
-         (some-> ^js ((:app/getConfiguration state) "calva-backseat-driver")
-                 (.get config-path))
+       (and (keyword? x)
+            (string/starts-with? (str x) ":vscode/config."))
+       (some-> ^js ((:app/getConfiguration state) "calva-backseat-driver")
+               (.get (second (re-find #"(?:\.)(.*?)$" (str x)))))
 
-         :else
-         x)))
+       :else x))
    action-or-effect))
 
 (defn enrich-with-args [actions args]


### PR DESCRIPTION
We had a regression in how we enriched state from config

This restores the old (and better) way we did it, and should:

* Fix #39

We'll see.